### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeout to external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Returning `Result<(), Box<dyn Error>>` from `main` and using the `?` operator for file operations exposes raw OS error details (like paths and OS error codes) to the user when an operation fails.
 **Learning:** In CLI applications, the default Rust error formatter for `main` returning `Result` is verbose and intended for debugging, making it unsuitable for user-facing output as it violates the principle of failing securely and not leaking internal details.
 **Prevention:** Do not return `Result` from `main` when standard user-facing error handling is required. Instead, use explicit `match` blocks for operations that can fail, log generic, safe error messages to the user, and exit securely.
+
+## 2024-04-20 - Enforce Timeouts on External API Calls
+**Vulnerability:** External API requests (e.g., using `reqwest::blocking::get`) without explicit timeouts can hang indefinitely if the remote server becomes unresponsive. This can lead to resource exhaustion and Denial of Service (DoS) in the application.
+**Learning:** Default HTTP clients often do not enforce a strict timeout. It is critical to explicitly configure a reasonable timeout (e.g., 5-10 seconds) for all external network requests to ensure the application fails fast and gracefully instead of hanging.
+**Prevention:** Instantiate a custom HTTP client configured with a timeout (e.g., `Client::builder().timeout(Duration::from_secs(5)).build()`) and use it for requests instead of relying on default convenience functions like `reqwest::blocking::get`. Ensure the client building process securely handles potential errors without panicking.

--- a/Misc-Projects/random_quote/src/main.rs
+++ b/Misc-Projects/random_quote/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         Ok(c) => c,
         Err(_) => {
             eprintln!("Error: Failed to initialize HTTP client. Exiting securely.");
-            return;
+            std::process::exit(1);
         }
     };
 

--- a/Misc-Projects/random_quote/src/main.rs
+++ b/Misc-Projects/random_quote/src/main.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
-use reqwest::blocking::get;
+use reqwest::blocking::Client;
+use std::time::Duration;
 
 pub type Response = Vec<Quote>;
 
@@ -12,8 +13,17 @@ pub struct Quote {
 }
 
 fn main() {
+    // 🛡️ Sentinel: Add timeout to external API calls to prevent DoS via hanging connections
+    let client = match Client::builder().timeout(Duration::from_secs(5)).build() {
+        Ok(c) => c,
+        Err(_) => {
+            eprintln!("Error: Failed to initialize HTTP client. Exiting securely.");
+            return;
+        }
+    };
+
     // 🛡️ Sentinel: Fix unhandled panics by catching and handling errors securely
-    match get("https://zenquotes.io/api/random") {
+    match client.get("https://zenquotes.io/api/random").send() {
         Ok(res) => {
             match res.json::<Response>() {
                 Ok(quotes) => {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unbounded external API calls.
🎯 **Impact:** If `https://zenquotes.io/api/random` hangs or is slow, the application could wait indefinitely resulting in a hanging application (resource exhaustion/Denial of Service).
🔧 **Fix:** Replaced `reqwest::blocking::get` with a custom `Client` containing a 5-second timeout, ensuring the app fails gracefully if the API is slow. Also made sure the client securely builds without using `unwrap()` to prevent internal panics. Added a learning to `.jules/sentinel.md`.
✅ **Verification:** Run `cd Misc-Projects/random_quote && cargo run` to verify the functionality remains intact. The code was tested with Cargo.

---
*PR created automatically by Jules for task [12349462552145451732](https://jules.google.com/task/12349462552145451732) started by @partrita*